### PR TITLE
Change Checking Database line to use variable.

### DIFF
--- a/sbfspot-config
+++ b/sbfspot-config
@@ -785,7 +785,7 @@ do_install()
 		install_pkg "$dbtype-client"
 
 		echo "Checking database..."
-		$dbtype -h $SQL_Hostname -u $SQL_Username -p$SQL_Password $SQL_Database -B --disable-column-names -e 'SELECT * FROM SBFspot.Config WHERE `Key`="SchemaVersion";' &>"$tmp_dir/sqldb.test"
+		$dbtype -h $SQL_Hostname -u $SQL_Username -p$SQL_Password $SQL_Database -B --disable-column-names -e 'SELECT * FROM '$SQL_Database'.Config WHERE `Key`="SchemaVersion";' &>"$tmp_dir/sqldb.test"
 
 		# Check for errors
 		local sql_error=$(grep -i "ERROR [^:]*: " $tmp_dir/sqldb.test)


### PR DESCRIPTION
When using MySQL, sometimes you may have a different database name (e.g. updating from a previous version).

Rather than failing/aborting at the "Checking database" step if the database name isn't "SBFSpot", this minor change uses the database name defined in the config steps of the tool, allowing installation to proceed as expected.